### PR TITLE
fix frame stats updates with onHiveFrameSideCellsDetected subscription

### DIFF
--- a/src/components/models/db/index.ts
+++ b/src/components/models/db/index.ts
@@ -1,8 +1,11 @@
 //@ts-nocheck
 import Dexie from 'dexie'
 import { addCustomIndexes } from './addCustomIndexes'
+import { FRAME_SIDE_CELL_TN } from '../frameSideCells'
 
 const DB_NAME = 'gratheon'
+const DB_VERSION = 3
+
 export const db = new Dexie(DB_NAME, {
 	autoOpen: true
 })
@@ -10,6 +13,10 @@ Dexie.debug = 'dexie'
 
 export async function dropDatabase(){
 	return await db.delete()
+}
+
+const graphqlToTableMap = {
+	'framesidecells': FRAME_SIDE_CELL_TN,
 }
 
 export function syncGraphqlSchemaToIndexDB(schemaObject) {
@@ -33,12 +40,17 @@ export function syncGraphqlSchemaToIndexDB(schemaObject) {
 				fieldStrings.push(field.name == 'id' ? '&id' : field.name)
 			}
 
-			dbSchema[objName] = fieldStrings.join(', ')
+			let table_name = objName
+			if (graphqlToTableMap[objName]) {
+				table_name = graphqlToTableMap[objName]
+			}
+
+			dbSchema[table_name] = fieldStrings.join(', ')
 		}
 	}
 	try {
 		addCustomIndexes(dbSchema)
-		db.version(2).stores(dbSchema)
+		db.version(DB_VERSION).stores(dbSchema)
 	} catch (e) {
 		console.error(e)
 		throw e

--- a/src/components/models/db/writeHooks.ts
+++ b/src/components/models/db/writeHooks.ts
@@ -74,7 +74,7 @@ export const writeHooks = {
 
 		cells.frameSideId = +cells.id
 		cells.id = +cells.id
-		await upsertEntityWithNumericID('framesidecells', cells)
+		await upsertEntityWithNumericID('files_frame_side_cells', cells)
 	},
 	File: async (_, entity) => {
 		await upsertEntityWithNumericID('file', entity)

--- a/src/components/models/frameSideCells.ts
+++ b/src/components/models/frameSideCells.ts
@@ -23,13 +23,24 @@ export type HiveInspectionCellStats = {
 	cappedBroodPercent?: number
 }
 
-// workerBeeCount: number
-// queenCount: number
-// varroaCount: number
+export const FRAME_SIDE_CELL_TN = 'files_frame_side_cells'
+
+export function newFrameSideCells(id, hiveId): FrameSideCells{
+	return {
+		id,
+		frameSideId: id,
+		hiveId,
+		broodPercent: 0,
+		honeyPercent: 0,
+		pollenPercent: 0,
+		eggsPercent: 0,
+		cappedBroodPercent: 0
+	}
+}
 
 export async function getFrameSideCells(frameSideId: number): Promise<FrameSideCells | null> {
 	try {
-		return await db['framesidecells'].get(+frameSideId)
+		return await db[FRAME_SIDE_CELL_TN].get(+frameSideId)
 	} catch (e) {
 		console.error(e)
 		return null
@@ -59,13 +70,22 @@ export async function updateFrameStat(
 	}
 
 	try {
-		await db['framesidecells'].put(cells)
+		await db[FRAME_SIDE_CELL_TN].put(cells)
 	} catch (e) {
 		console.error(e)
 		throw e
 	}
 
 	return cells;
+}
+
+export async function updateFrameSideCells(cells: FrameSideCells) {
+	try {
+		await db[FRAME_SIDE_CELL_TN].put(cells)
+	} catch (e) {
+		console.error(e)
+		throw e
+	}
 }
 
 export async function getHiveInspectionStats(frames: Frame[]): Promise<HiveInspectionCellStats> {
@@ -116,18 +136,18 @@ export async function getHiveInspectionStats(frames: Frame[]): Promise<HiveInspe
 
 
 export async function deleteCellsByFrameSideIDs(frameSideIds: number[]) {
-    try {
-        await db['framesidecells'].where('frameSideId').anyOf(frameSideIds).delete()
-    } catch (e) {
-        console.error(e)
-        throw e
-    }
+	try {
+		await db[FRAME_SIDE_CELL_TN].where('frameSideId').anyOf(frameSideIds).delete()
+	} catch (e) {
+		console.error(e)
+		throw e
+	}
 }
 
 export async function enrichFramesWithSideCells(frames: Frame[]): Promise<Frame[] | null> {
 	try {
 		const frameSideIds = frames.map((frame) => frame.leftId).concat(frames.map((frame) => frame.rightId))
-		const frameSideCells = await db['framesidecells'].where('frameSideId').anyOf(frameSideIds).toArray()
+		const frameSideCells = await db[FRAME_SIDE_CELL_TN].where('frameSideId').anyOf(frameSideIds).toArray()
 
 		const frameSideCellsMap = new Map<number, FrameSideCells>()
 		frameSideCells.forEach((frameSideCell) => {


### PR DESCRIPTION
## Problem
In hive edit view, box component frames do not get updated with statistics after new files are uploaded and are processed

## Changes
- add onHiveFrameSideCellsDetected subscription in hive box component
- add indexed db table naming customization
- customize indexedb files_frame_side_cells table naming
- add `newFrameSideCells` for new entry addition

https://github.com/Gratheon/web-app/assets/445122/dbf38366-ab44-4a83-b849-1872b7db4db4


