### PR TITLE
Add treatment, queen age, update hive list view, extract date components

### DIFF
--- a/src/components/api/schema.ts
+++ b/src/components/api/schema.ts
@@ -1,13 +1,5 @@
 import { buildSchema } from 'graphql'
 
-export type Family = {
-  hiveId?: number //reference
-  id: number
-  race: string
-  added: string
-}
-
-
 export const schemaSDL = `
 type Apiary {
     id: ID!

--- a/src/components/colors.less
+++ b/src/components/colors.less
@@ -11,6 +11,7 @@
 @color-error-general-border: #ffd07a;
 
 @color-error-bg: #cd311e;
+@color-warning-bg: #6200cd;
 
 @color-blue-selected: #0088ff;
 @color-hover-bg: #f3f3f3;

--- a/src/components/models/family.ts
+++ b/src/components/models/family.ts
@@ -1,7 +1,13 @@
-import { Family } from '@/components/api/schema'
-
 import { db } from './db'
 
+export type Family = {
+	hiveId?: number //reference
+	id: number
+	race: string
+	added: string
+	age?: number // in years
+  }
+  
 export async function getFamilyByHive(hiveId: number): Promise<Family> {
 	try {
 		return await db['family'].get({ hiveId })

--- a/src/components/models/hive.ts
+++ b/src/components/models/hive.ts
@@ -7,6 +7,7 @@ export type Hive = {
 	familyId?: number
 	beeCount?: number
 	inspectionCount?: number
+	status?: string
 }
 
 export async function getHive(id: number): Promise<Hive> {

--- a/src/components/models/inspections.ts
+++ b/src/components/models/inspections.ts
@@ -1,4 +1,4 @@
-import { Family } from '../api/schema'
+import { Family } from './family'
 import { Box } from './boxes'
 import { db } from './db'
 import { HiveInspectionCellStats } from './frameSideCells'

--- a/src/components/page/accountEdit/billing/index.tsx
+++ b/src/components/page/accountEdit/billing/index.tsx
@@ -10,6 +10,8 @@ import T from '@/components/shared/translate'
 import metrics from '@/components/metrics'
 
 import { de, et, fr, pl, ru, tr } from 'date-fns/locale'
+import DateTimeAgo from '@/components/shared/dateTimeAgo'
+import DateFormat from '@/components/shared/dateFormat'
 const loadedDateLocales = { de, et, fr, pl, ru, tr }
 
 export default function Billing({ user }) {
@@ -52,7 +54,7 @@ export default function Billing({ user }) {
 	}
 
 	let expirationError = user.isSubscriptionExpired ? (
-		<MessageError error={<T>Subscription has expired, please extend</T>} />
+		<MessageSuccess isWarning={true} title={<T>Subscription has expired, please extend</T>} />
 	) : null
 
 	if (!user.lang) {
@@ -68,21 +70,21 @@ export default function Billing({ user }) {
 			)}
 			{stripeStatus === 'cancel' && <MessageError error={<T>Payment was cancelled</T>} />}
 
+			{expirationError}
+
 			<div style="margin-bottom:5px; border: 1px dotted gray; padding: 10px; border-radius: 5px;">
 				<h3><T ctx="this is a headline for billing form">Billing</T></h3>
-
-				{expirationError}
 				{error && <MessageError error={error} />}
 				{errorCancel && <MessageError error={errorCancel} />}
 
 				<div style=" display: flex">
 					<div style={{ flexGrow: 1, marginTop: 5 }}>
 						<div>
-							<T>Account created</T>: {format(new Date(user.date_added), 'dd MMMM yyyy, hh:mm', dateLangOptions)}
+							<T>Billing plan</T>: {user.billingPlan}
 						</div>
 
 						<div>
-							<a href="https://gratheon.com/prices.html"><T>Billing plan</T></a>: {user.billingPlan}
+							<T>Account created</T>: {format(new Date(user.date_added), 'dd MMMM yyyy, hh:mm', dateLangOptions)}
 						</div>
 
 						{user.isSubscriptionExpired &&
@@ -93,16 +95,18 @@ export default function Billing({ user }) {
 
 						{!user.isSubscriptionExpired &&
 							<div>
-								<T>Expires in</T> {formatDistance(new Date(user.date_expiration), new Date(), dateLangOptions)} &mdash; {format(new Date(user.date_expiration), 'dd MMMM yyyy, hh:mm', dateLangOptions)}
+								<T>Expires in</T> 
+								<DateTimeAgo dateString={user.date_expiration} lang={user.lang} /> &mdash; 
+								<DateFormat datetime={user.date_expiration} lang={user.lang} />
 							</div>
 						}
 					</div>
 
 					<div>
-						{!user.hasSubscription && (
+						{(!user.hasSubscription || user.isSubscriptionExpired) && (
 							<Button onClick={onSubscribeClick}><T ctx="this is a button that redirects to billing page to pay">Subscribe</T></Button>
 						)}
-						{user.hasSubscription && (
+						{user.hasSubscription && !user.isSubscriptionExpired && (
 							<Button onClick={onCancelSubscription}><T ctx="this is a button that cancels billing subscription">Cancel subscription</T></Button>
 						)}
 					</div>

--- a/src/components/page/apiaryList/apiaryListRow/index.less
+++ b/src/components/page/apiaryList/apiaryListRow/index.less
@@ -1,5 +1,25 @@
 @import "@/components/colors.less";
 
+table {
+	th {
+		text-align: left;
+		padding: 2px 10px;
+		border-bottom: 1px solid #eeeeee;
+	}
+
+	td {
+		text-align: left;
+		border-bottom: 1px solid #eeeeee;
+		border-right: 1px solid #eeeeee;
+		padding: 2px 10px;
+
+		&:last-child {
+			border-right: none;
+		}
+	}
+
+}
+
 .apiary {
 	padding: 10px 0;
 	border-bottom: 1px solid #eeeeee;
@@ -13,11 +33,12 @@
 			flex-grow: 2;
 		}
 
-		.buttons{
-			text-align:right;
+		.buttons {
+			text-align: right;
 			flex-grow: 1;
-			a{
-				margin-bottom:2px;
+
+			a {
+				margin-bottom: 2px;
 			}
 		}
 	}

--- a/src/components/page/apiaryList/apiaryListRow/index.tsx
+++ b/src/components/page/apiaryList/apiaryListRow/index.tsx
@@ -6,7 +6,6 @@ import HivesPlaceholder from '@/components/shared/hivesPlaceholder'
 import T from '@/components/shared/translate'
 
 import HiveIcon from '@/components/icons/hive'
-import HandIcon from '@/components/icons/handIcon'
 
 import styles from './index.less'
 import BeeCounter from '@/components/shared/beeCounter'
@@ -14,24 +13,26 @@ import { NavLink } from 'react-router-dom'
 import Link from '@/components/shared/link'
 import ListIcon from '@/components/icons/listIcon'
 import TableIcon from '@/components/icons/tableIcon'
+import DateTimeAgo from '@/components/shared/dateTimeAgo'
 
-export default function apiaryListRow(props) {
-	const { apiary } = props
+export default function apiaryListRow({ apiary, user }) {
+
 	const [listType, setListType] = React.useState(localStorage.getItem('apiaryListType.' + apiary.id) || 'list')
 
 	return (
 		<div className={styles.apiary}>
 			<div className={styles.apiaryHead}>
 				<h2><Link href={`/apiaries/edit/${apiary.id}`}>{apiary.name ? apiary.name : '...'}</Link></h2>
+
 				<div className={styles.buttons}>
-					{listType == 'table' && apiary.hives.length>0 && <Button onClick={() => {
+					{listType == 'table' && apiary.hives.length > 0 && <Button onClick={() => {
 						setListType('list')
 						localStorage.setItem('apiaryListType.' + apiary.id, 'list')
 					}}>
 						<ListIcon />
 					</Button>}
 
-					{listType == 'list' && apiary.hives.length>0 && <Button onClick={() => {
+					{listType == 'list' && apiary.hives.length > 0 && <Button onClick={() => {
 						setListType('table')
 						localStorage.setItem('apiaryListType.' + apiary.id, 'table')
 					}}>
@@ -63,9 +64,12 @@ export default function apiaryListRow(props) {
 					<table>
 						<thead>
 							<tr>
-								<th><T ctx="table header">Hive</T></th>
-								<th><T ctx="table header">Name</T></th>
-								<th><T ctx="table header">Bees</T></th>
+								<th></th>
+								<th><T ctx="table header of beekeeping app, this is a column for beehive name, start with uppercase latter">Name</T></th>
+								<th><T ctx="table header of beekeeping app, start with uppercase latter">Bee count</T></th>
+								<th><T ctx="table header of beekeeping app, this is a bee colony information, start with uppercase latter">Colony status</T></th>
+								<th><T ctx="table header of beekeeping app, this is a bee queen info, start with uppercase latter">Queen age</T></th>
+								<th><T ctx="table header of beekeeping app, this column is about anti-varroa mite treatment, in amount of days, start with uppercase latter">Last treatment</T></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -78,11 +82,18 @@ export default function apiaryListRow(props) {
 											</NavLink>
 										</td>
 										<td>
-											<div className={styles.title}>{hive.name}</div>
+											<NavLink className={styles.title} to={`/apiaries/${apiary.id}/hives/${hive.id}`}>
+												{hive.name}
+											</NavLink>
 										</td>
 
 										<td>
 											<BeeCounter count={hive.beeCount} />
+										</td>
+										<td>{hive.status}</td>
+										<td>{hive?.family?.age}</td>
+										<td>
+											{hive?.family?.lastTreatment && <DateTimeAgo dateString={hive?.family?.lastTreatment} lang={user.lang} />}
 										</td>
 									</tr>
 								))}

--- a/src/components/page/apiaryList/index.tsx
+++ b/src/components/page/apiaryList/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { gql, useQuery, useSubscription } from '@/components/api/index'
+import { gql, useQuery } from '@/components/api/index'
 
 import Loader from '@/components/shared/loader'
 import ErrorMsg from '@/components/shared/messageError'
@@ -9,8 +9,11 @@ import T from '@/components/shared/translate'
 import ApiaryListRow from './apiaryListRow'
 import ApiariesPlaceholder from './apiariesPlaceholder'
 import Button from '@/components/shared/button'
+import { getUser } from '@/components/models/user'
+import { useLiveQuery } from 'dexie-react-hooks'
 
 export default function ApiaryList(props) {
+	let user = useLiveQuery(() => getUser(), [], null)
 	const { loading, error, data } = useQuery(gql`
 		{
 			apiaries {
@@ -21,6 +24,13 @@ export default function ApiaryList(props) {
 					id
 					name
 					beeCount
+					status
+
+					family{
+						id
+						age
+						lastTreatment
+					}
 
 					boxes {
 						id
@@ -33,15 +43,6 @@ export default function ApiaryList(props) {
 		}
 	`)
 
-	const { data: apiaryUpdated } = useSubscription(gql`
-		subscription onApiaryUpdated {
-			onApiaryUpdated {
-				id
-				name
-			}
-		}
-	`)
-
 	if (loading) {
 		return <Loader />
 	}
@@ -50,18 +51,18 @@ export default function ApiaryList(props) {
 
 	return (
 		<div>
-			<ErrorMsg error={error} />
+			<ErrorMsg error={error} borderRadius={0} />
 			<div style={{ maxWidth: 800, paddingLeft: 20 }}>
-				{!apiaries || (apiaries.length === 0 && <ApiariesPlaceholder />)}
+				{apiaries !== null && apiaries?.length === 0 && <ApiariesPlaceholder />}
 
 				{apiaries &&
 					apiaries.map((apiary, i) => (
-						<ApiaryListRow key={i} apiary={apiary} selectedId={props.id} />
+						<ApiaryListRow key={i} apiary={apiary} user={user} />
 					))}
 
 				<div style={{ textAlign: 'center', marginTop: 20 }}>
 					<Button 
-						color={apiaries.length === 0 ? 'green' : 'white'}
+						color={apiaries && apiaries.length === 0 ? 'green' : 'white'}
 						href="/apiaries/create"><T ctx="its a button">Setup new apiary</T></Button>
 				</div>
 			</div>

--- a/src/components/page/hiveEdit/boxes/hiveButtons.tsx
+++ b/src/components/page/hiveEdit/boxes/hiveButtons.tsx
@@ -17,6 +17,7 @@ import ErrorMessage from '@/components/shared/messageError'
 import { useState } from 'react'
 import metrics from '@/components/metrics'
 import styles from './styles.less'
+import { PopupButton, PopupButtonGroup } from '@/components/shared/popupButton'
 
 export default function HiveButtons({
 	apiaryId,
@@ -24,6 +25,7 @@ export default function HiveButtons({
 }) {
 	let navigate = useNavigate()
 	const [adding, setAdding] = useState(false)
+
 	let [addBoxMutation, { error }] =
 		useMutation(`mutation addBox($hiveId: ID!, $position: Int!, $type: BoxType!) {
 	addBox(hiveId: $hiveId, position: $position, type: $type) {
@@ -66,6 +68,7 @@ export default function HiveButtons({
 		<>
 			<ErrorMessage error={error} />
 			<div className={styles.hiveButtons}>
+
 				<Button
 					title="Add box on top"
 					loading={adding}
@@ -74,38 +77,43 @@ export default function HiveButtons({
 				>
 					<AddBoxIcon /><span><T ctx="this is a button to add new section of beehive, a deep box that is intended for brood frames">Add deep</T></span>
 				</Button>
-				<Button
-					loading={adding}
-					title="Add super on top"
-					onClick={() => onBoxAdd(boxTypes.SUPER)}
-				>
-					<AddSuperIcon /><span><T ctx="this is a button to add new section of beehive, a super box that is intended for honey frames">Add super</T></span>
-				</Button>
-				<Button
-					loading={adding}
-					title="Add gate"
-					onClick={() => onBoxAdd(boxTypes.GATE)}
-				>
-					<GateIcon /><span><T ctx="this is a button to add new section of beehive, specifically holes, an entrance">Add base</T></span>
-				</Button>
-				<Button
-					loading={adding}
-					title="Add ventilation"
-					onClick={() => onBoxAdd(boxTypes.VENTILATION)}
-				><span><T ctx="this is a button to add tiny part of beehive, specifically holes on top for ventilation">Add inner lid</T></span>
-				</Button>
-				<Button
-					loading={adding}
-					title="Add queen excluder"
-					onClick={() => onBoxAdd(boxTypes.QUEEN_EXCLUDER)}
-				><span><T ctx="this is a button to add tiny part of beehive, a horizontal layer that prevents queen bee from moving through this">Add queen excluder</T></span>
-				</Button>
-				<Button
-					loading={adding}
-					title="Add feeder"
-					onClick={() => onBoxAdd(boxTypes.HORIZONTAL_FEEDER)}
-				><span><T ctx="this is a button to add tiny part of beehive, a horizontal box where sugar syrup can be poured to feed bees">Add feeder</T></span>
-				</Button>
+				<PopupButtonGroup>
+					<Button
+						loading={adding}
+						title="Add super on top"
+						onClick={() => onBoxAdd(boxTypes.SUPER)}
+					>
+						<AddSuperIcon /><span><T ctx="this is a button to add new section of beehive, a super box that is intended for honey frames">Add super</T></span>
+					</Button>
+
+					<PopupButton>
+						<Button
+							loading={adding}
+							title="Add gate"
+							onClick={() => onBoxAdd(boxTypes.GATE)}
+						>
+							<GateIcon /><span><T ctx="this is a button to add new section of beehive, specifically holes, an entrance">Add base</T></span>
+						</Button>
+						<Button
+							loading={adding}
+							title="Add ventilation"
+							onClick={() => onBoxAdd(boxTypes.VENTILATION)}
+						><span><T ctx="this is a button to add tiny part of beehive, specifically holes on top for ventilation">Add inner lid</T></span>
+						</Button>
+						<Button
+							loading={adding}
+							title="Add queen excluder"
+							onClick={() => onBoxAdd(boxTypes.QUEEN_EXCLUDER)}
+						><span><T ctx="this is a button to add tiny part of beehive, a horizontal layer that prevents queen bee from moving through this">Add queen excluder</T></span>
+						</Button>
+						<Button
+							loading={adding}
+							title="Add feeder"
+							onClick={() => onBoxAdd(boxTypes.HORIZONTAL_FEEDER)}
+						><span><T ctx="this is a button to add tiny part of beehive, a horizontal box where sugar syrup can be poured to feed bees">Add feeder</T></span>
+						</Button>
+					</PopupButton>
+				</PopupButtonGroup>
 			</div>
 		</>
 	)

--- a/src/components/page/hiveEdit/boxes/styles.less
+++ b/src/components/page/hiveEdit/boxes/styles.less
@@ -12,15 +12,8 @@
 }
 
 .hiveButtons {
-	display: grid;
-	gap: 1px;
-	grid-template-columns: repeat(2, 1fr);
-
+	display: flex;
 	padding: @mobilePadPx;
 
-	@media @tabletAndUp {
-		display: grid;
-		gap: 1px;
-		grid-template-columns: repeat(3, 1fr);
-	}
+	flex-direction: row-reverse;
 }

--- a/src/components/page/hiveEdit/hiveAdvisor/index.tsx
+++ b/src/components/page/hiveEdit/hiveAdvisor/index.tsx
@@ -30,8 +30,9 @@ mutation generateHiveAdvice($hiveID: ID, $adviceContext: JSON, $langCode: String
 	let showLoader = (loading || saving)
 	return <div>
 		<ErrorMsg error={errorGet || mutateError} />
+
 		<div className={style.wrap}>
-			<div style="flex-grow:1; text-align:center;">
+			<div style={`flex-grow:1; text-align:center;${data?.getExistingHiveAdvice ? '' : 'margin-top:50px;'}`}>
 				{showLoader && <Loader />}
 
 				{!showLoader && <div className={style.message}>
@@ -67,26 +68,26 @@ mutation generateHiveAdvice($hiveID: ID, $adviceContext: JSON, $langCode: String
 						delete boxes[i].color
 
 						for (let j in frames) {
-							if(!frames[j].leftSide || !frames[j].rightSide) continue
+							if (!frames[j].leftSide || !frames[j].rightSide) continue
 
 							frames[j].leftSide.cells = await getFrameSideCells(+frames[j].leftId)
 							frames[j].rightSide.cells = await getFrameSideCells(+frames[j].rightId)
 
-							let leftFile = await getFrameSideFile({frameSideId: +frames[j].leftId})
+							let leftFile = await getFrameSideFile({ frameSideId: +frames[j].leftId })
 
 							//@ts-ignore
 							frames[j].leftSide.detectedQueenCupsCount = leftFile?.detectedQueenCups.length;
 							//@ts-ignore
 							frames[j].leftSide.isQueenDetected = leftFile?.queenDetected;
 
-							let rightFile = await getFrameSideFile({frameSideId: +frames[j].rightId})
+							let rightFile = await getFrameSideFile({ frameSideId: +frames[j].rightId })
 
 							//@ts-ignore
 							frames[j].leftSide.detectedQueenCupsCount = rightFile?.detectedQueenCups.length;
 							//@ts-ignore
 							frames[j].leftSide.isQueenDetected = rightFile?.queenDetected;
 						}
-						
+
 						adviceContext['frames'][boxes[i].id] = frames
 					}
 

--- a/src/components/page/hiveEdit/hiveTopInfo/hiveTopEditForm/index.tsx
+++ b/src/components/page/hiveEdit/hiveTopInfo/hiveTopEditForm/index.tsx
@@ -17,7 +17,7 @@ import { getFamilyByHive, updateFamily } from '@/components/models/family'
 
 import Loader from '@/components/shared/loader'
 import ErrorMessage from '@/components/shared/messageError'
-import { Family } from '@/components/api/schema'
+import { Family } from '@/components/models/family'
 import { InspectionSnapshot } from '@/components/models/inspections'
 import { getFramesByHive } from '@/components/models/frames'
 import { getHiveInspectionStats, deleteCellsByFrameSideIDs } from '@/components/models/frameSideCells'
@@ -149,7 +149,8 @@ export default function HiveEditDetails({ apiaryId, hiveId, buttons }) {
 					family = {
 						id: null,
 						race: '',
-						added: ''
+						added: '',
+						age: null
 					}
 				}
 

--- a/src/components/page/hiveEdit/hiveTopInfo/index.tsx
+++ b/src/components/page/hiveEdit/hiveTopInfo/index.tsx
@@ -24,7 +24,6 @@ import { collectFrameSideIDsFromFrames } from '@/components/models/frameSide'
 import { deleteFilesByFrameSideIDs } from '@/components/models/frameSideFile'
 import MessageSuccess from '@/components/shared/messageSuccess'
 import InspectionIcon from '@/components/icons/inspection'
-import ShareIcon from '@/components/icons/share'
 import VisualFormSubmit from '@/components/shared/visualForm/VisualFormSubmit'
 import HiveTopEditForm from './hiveTopEditForm'
 
@@ -115,8 +114,8 @@ export default function HiveEditDetails({ apiaryId, hiveId }) {
 
 
 
-				{!editable && <Button onClick={() => setEditable(!editable)}>Edit</Button>}
-				{editable && <Button onClick={() => setEditable(!editable)}>Complete</Button>}
+				{!editable && <Button onClick={() => setEditable(!editable)}><T ctx="this is a button to allow editing by displaying a form">Edit</T></Button>}
+				{editable && <Button onClick={() => setEditable(!editable)}><T ctx="this is a button to compete editing of a form, but it is not doing any saving because saving is done automatically, this just switches form to view mode">Complete</T></Button>}
 
 				<PopupButton align="right">
 					<DeactivateButton hiveId={hive.id} />

--- a/src/components/page/hiveEdit/index.tsx
+++ b/src/components/page/hiveEdit/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useLiveQuery } from 'dexie-react-hooks'
 
-import { gql, useQuery } from '@/components/api'
+import { useQuery } from '@/components/api'
 import Boxes from './boxes'
 
 import HIVE_QUERY from './_api/hiveQuery.graphql'
@@ -30,6 +30,7 @@ import ListIcon from '@/components/icons/listIcon'
 import TableIcon from '@/components/icons/tableIcon'
 
 import styles from './styles.less'
+import Treatments from './treatments'
 
 export default function HiveEditForm() {
 	const { state } = useLocation();
@@ -163,6 +164,9 @@ export default function HiveEditForm() {
 
 				<div className={styles.frameWrap}>
 					{!frameId && !boxId && <HiveButtons apiaryId={apiaryId} hiveId={hiveId} />}
+
+
+					{!frameId && <Treatments hiveId={hiveId} boxId={boxId} />}
 
 					<Frame
 						box={box}

--- a/src/components/page/hiveEdit/treatments/index.tsx
+++ b/src/components/page/hiveEdit/treatments/index.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+
+import { gql, useMutation, useQuery } from "@/components/api";
+import Button from "@/components/shared/button";
+import ErrorMessage from '@/components/shared/messageError'
+import T from "@/components/shared/translate";
+import Loader from "@/components/shared/loader";
+import DateFormat from "@/components/shared/dateFormat";
+import MessageSuccess from "@/components/shared/messageSuccess";
+import TreatmentList from "./treatmentList";
+
+export default function Treatments({ hiveId, boxId = null }) {
+	const [treating, setTreating] = useState(false)
+	const [treatmentType, setTreatmentType] = useState('')
+	const [addedMsg, setAddedMsg] = useState('')
+
+
+	let [addTreatmentMutation, { error }] =
+		useMutation(`mutation treatHive($treatment: TreatmentOfHiveInput!) {
+	treatHive(treatment: $treatment)
+}
+`)
+	let [addTreatmentBoxMutation, { error: error2 }] =
+		useMutation(`mutation treatBox($treatment: TreatmentOfBoxInput!) {
+	treatBox(treatment: $treatment)
+}
+`)
+
+	async function onTreat() {
+		setTreating(true)
+
+		if (boxId) {
+			await addTreatmentBoxMutation({
+				treatment: {
+					boxId: +boxId,
+					hiveId: +hiveId,
+					type: treatmentType,
+				}
+			})
+		} else {
+			await addTreatmentMutation({
+				treatment: {
+					hiveId: +hiveId,
+					type: treatmentType,
+				}
+			})
+		}
+		setTreatmentType('')
+		setAddedMsg('Treatment added')
+		setTreating(false)
+	}
+
+	return (
+		<div style="padding: 20px 10px;">
+			{addedMsg && <MessageSuccess title={<T>Treatment added</T>} />}
+			<ErrorMessage error={error || error2} />
+
+			{treating && <Loader />}
+			{!treating && <TreatmentList hiveId={hiveId} boxId={boxId} />}
+
+			<div style="display:flex;">
+				<input
+					type="text"
+					style="padding:5px 20px; height: 40px; flex-grow:1"
+					onChange={(event) => {
+						setTreatmentType((event.target as HTMLInputElement)?.value)
+					}}
+					value={treatmentType}
+					placeholder="Apivar, Oxalic acid ..." />
+
+				<Button
+					disabled={!treatmentType}
+					loading={treating}
+					onClick={() => onTreat()}
+				><T>Add treatment</T></Button>
+			</div>
+		</div>
+	)
+}

--- a/src/components/page/hiveEdit/treatments/treatmentList/index.tsx
+++ b/src/components/page/hiveEdit/treatments/treatmentList/index.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+
+import { gql, useMutation, useQuery } from "@/components/api";
+import Button from "@/components/shared/button";
+import ErrorMessage from '@/components/shared/messageError'
+import T from "@/components/shared/translate";
+import Loader from "@/components/shared/loader";
+import DateFormat from "@/components/shared/dateFormat";
+import MessageSuccess from "@/components/shared/messageSuccess";
+
+export default function TreatmentList({ hiveId, boxId = null }) {
+	let {
+		loading,
+		data,
+		error: errorGet,
+		errorNetwork
+	} = useQuery(gql`	query hive($id: ID!) {
+		hive(id: $id) {
+			family{
+				treatments{
+					id
+					type
+					added
+				}
+			}
+		}
+		}`,
+		{ variables: { id: +hiveId } })
+
+	if (loading) {
+		return <Loader />
+	}
+
+
+	return (
+		<>
+			<ErrorMessage error={errorGet || errorNetwork} />
+
+			{data.hive.family.treatments.length == 0 && <p><T>No treatments added yet</T></p>}
+			{data.hive.family.treatments.length > 0 &&
+				<table width="100%">
+					<thead>
+						<tr>
+							<th><T>Treatment type</T></th>
+							<th width="200"><T>Time</T></th>
+						</tr>
+					</thead>
+					<tbody>
+						{data.hive.family.treatments.map((treatment) => (
+							<tr key={treatment.id}>
+								<td>{treatment.type}</td>
+								<td>
+									<DateFormat datetime={treatment.added} />
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			}
+		</>
+	)
+}

--- a/src/components/page/inspectionList/index.tsx
+++ b/src/components/page/inspectionList/index.tsx
@@ -22,6 +22,7 @@ import InspectionView from './inspectionView'
 import DateFormat from '@/components/shared/dateFormat'
 import HiveIcon from '@/components/icons/hive'
 import InspectionIcon from '@/components/icons/inspection'
+import { getUser } from '@/components/models/user'
 
 export default function InspectionList() {
 	let { apiaryId, hiveId, boxId, frameId, frameSideId, inspectionId } = useParams()
@@ -39,6 +40,7 @@ export default function InspectionList() {
 		errorGet,
 		errorNetwork
 
+	let user = useLiveQuery(() => getUser(), [], null)
 	const inspections = useLiveQuery(() => listInspections(+hiveId), [hiveId], null)
 	// if local cache is empty - query
 	if (inspections == null || inspections.length === 0) {
@@ -70,7 +72,7 @@ export default function InspectionList() {
 
 	if (hive) {
 		breadcrumbs[1] = {
-			icon: <HiveIcon size={12}/>,
+			icon: <HiveIcon size={12} />,
 			name: <>«{hive.name}» <T>hive</T></>,
 			uri: `/apiaries/${apiaryId}/hives/${hiveId}`,
 		}
@@ -80,13 +82,9 @@ export default function InspectionList() {
 		let selectedInspection = inspections.find((i: Inspection) => i.id == +inspectionId)
 		if (selectedInspection) {
 			breadcrumbs[2] = {
-				icon: <InspectionIcon size={12}/>,
+				icon: <InspectionIcon size={12} />,
 				name: (<><DateFormat
-					options={{
-						month: 'long',
-						day: '2-digit',
-						year: 'numeric',
-					}}
+					lang={user.lang}
 					datetime={selectedInspection?.added}
 				/> <T>inspection</T>
 				</>),

--- a/src/components/shared/button/index.less
+++ b/src/components/shared/button/index.less
@@ -1,5 +1,11 @@
 @import '@/components/colors.less';
 
+button:not(:disabled) {
+	&:hover {
+		background: @color-btn-hover-black;
+	}
+}
+
 button {
 	position: relative;
 	border-radius: 3px;
@@ -27,15 +33,16 @@ button {
 		margin-left: 4px;
 	}
 
-	&:hover {
-		background: @color-btn-hover-black;
+	&:disabled {
+		background: gray;
+		cursor: not-allowed;
 	}
 
 	&[type='submit'] {
 		padding: 0 20px;
 	}
 
-	&.white{
+	&.white {
 		background: @color-btn-white-bg;
 		color: @color-btn-white-text;
 		border: 2px solid @color-btn-white-border;

--- a/src/components/shared/button/index.tsx
+++ b/src/components/shared/button/index.tsx
@@ -14,6 +14,7 @@ type ButtonProps = {
 	style?: any
 	title?: string
 	loading?: boolean
+	disabled?: boolean
 	type?: 'button' | 'submit' | 'reset' | undefined
 	children?: any
 	href?: string | null
@@ -27,6 +28,7 @@ export default function Button({
 	size = null,
 	color = 'black',
 	type = 'button',
+	disabled = false,
 	onClick = () => { },
 	onMouseOver = () => { },
 	onMouseOut = () => { },
@@ -60,7 +62,7 @@ export default function Button({
 	return (
 		<button
 			style={style}
-			disabled={loading}
+			disabled={disabled || loading}
 			type={type}
 			title={title}
 			className={classNames.join(' ')}

--- a/src/components/shared/dateFormat/index.tsx
+++ b/src/components/shared/dateFormat/index.tsx
@@ -1,21 +1,20 @@
 import React from 'react'
 
+import { format, formatDistance } from 'date-fns'
+import { de, et, fr, pl, ru, tr } from 'date-fns/locale'
+const loadedDateLocales = { de, et, fr, pl, ru, tr }
+
 type DateFormatProps = {
 	datetime: string
-	options?: any
+	lang?: string
 }
 
-export default function dateFormat({
-	datetime,
-	options = {
-		month: 'long',
-		day: '2-digit',
-		// year: 'numeric',
-	},
-}: DateFormatProps) {
+export default function DateFormat({ datetime, lang = 'en' }: DateFormatProps) {
+	const dateLangOptions = { locale: loadedDateLocales[lang] }
+
 	return (
 		<span className="date timeago" title={datetime}>
-			{new Intl.DateTimeFormat('en-GB', options).format(new Date(datetime))}
+			{format(new Date(datetime), 'dd MMMM yyyy, hh:mm', dateLangOptions)}
 		</span>
 	)
 }

--- a/src/components/shared/dateTimeAgo/index.tsx
+++ b/src/components/shared/dateTimeAgo/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import { formatDistance } from 'date-fns'
+import { de, et, fr, pl, ru, tr } from 'date-fns/locale'
+const loadedDateLocales = { de, et, fr, pl, ru, tr }
+
+export default function DateTimeAgo({ dateString, lang = 'en' }) {
+	const dateLangOptions = { locale: loadedDateLocales[lang] }
+
+	return <>{formatDistance(new Date(dateString), new Date(), dateLangOptions)}</>
+}

--- a/src/components/shared/messageError/index.less
+++ b/src/components/shared/messageError/index.less
@@ -3,7 +3,6 @@
 .errorMsgBig,
 .errorMsgSmall {
 	background-color: @color-error-bg;
-	border-radius: 5px;
 	padding: 5px 10px;
 	color: white;
 	display: flex;
@@ -36,7 +35,8 @@
 		font-family: Consolas, Courier, monospace;
 		white-space: pre-wrap;
 		word-wrap: break-word;
-		margin:0;
+		margin: 10px 0;
+
 	}
 
 	svg {

--- a/src/components/shared/messageError/index.tsx
+++ b/src/components/shared/messageError/index.tsx
@@ -4,7 +4,7 @@ import BearIcon from '@/components/icons/bear'
 import T from '../translate'
 import DeleteIcon from '@/components/icons/deleteIcon'
 
-export default function ErrorMsg({ error }) {
+export default function ErrorMsg({ error, borderRadius=5 }) {
     const [visible, setVisible] = useState(true);
 
     useEffect(() => {
@@ -15,7 +15,7 @@ export default function ErrorMsg({ error }) {
 
     if (!error || !visible) return null;
 
-	console.log({
+	console.error({
 		error
 	})
 
@@ -39,11 +39,15 @@ export default function ErrorMsg({ error }) {
 				<BearIcon size={24} />
 				<div>
 					<h3><T>Server error</T></h3>
+					<pre>Error name: {error?.name}</pre>
 					{error?.graphQLErrors &&
 						error.graphQLErrors.map((e, i) => {
 							return (
 								<pre key={i}>
-									<strong>{e.path?.join(' > ')}</strong> {e.message}
+									GraphQL error: {e.message}<br/>
+									Path: {e.originalError.extensions.exception.path?.join('.')}
+									{/* <br/><br/>
+									Stacktrace: {e.originalError.extensions.exception.stacktrace.join('\n')} */}
 								</pre>
 							)
 						})}
@@ -54,7 +58,7 @@ export default function ErrorMsg({ error }) {
 	}
 
 	// error can be a translation component
-	return <div className={styles.errorMsgSmall}>
+	return <div className={styles.errorMsgSmall} style={{borderRadius}}>
 		<BearIcon size={24} />
 		<div><h3>{error}</h3></div>
 		<DeleteIcon size={24} onClick={() => { setVisible(false) }} />

--- a/src/components/shared/messageSuccess/index.less
+++ b/src/components/shared/messageSuccess/index.less
@@ -2,6 +2,13 @@
 
 .successMsg {
 	background-color: @color-msg-success-green;
+}
+
+.warningMsg{
+	background-color: @color-warning-bg;
+}
+
+.msg{
 	color: white;
 	display: flex;
 	margin: 0;

--- a/src/components/shared/messageSuccess/index.tsx
+++ b/src/components/shared/messageSuccess/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import styles from './index.less'
 
-export default function MessageSuccess({ title = 'Saved!', message = '' }:{title?:any, message?:any}) {
+export default function MessageSuccess({ title = 'Saved!', message = '', isWarning=false }:{title?:any, message?:any, isWarning?:boolean}) {
 	return (
-		<div className={styles.successMsg}>
+		<div className={`${isWarning ? styles.warningMsg : styles.successMsg} ${styles.msg} `}>
 			<div>
 				<strong>{title}</strong>
 				{message && <p>{message}</p>}

--- a/src/components/uri.ts
+++ b/src/components/uri.ts
@@ -1,7 +1,7 @@
 import isDev from './isDev'
 
 // set to false if you want to develop with locally running backend
-const USE_PROD_BACKEND_FOR_DEV = true;
+const USE_PROD_BACKEND_FOR_DEV = false;
 
 export function grafanaUri() {
 	let uri = 'https://grafana.gratheon.com/'

--- a/src/components/uri.ts
+++ b/src/components/uri.ts
@@ -1,7 +1,7 @@
 import isDev from './isDev'
 
 // set to false if you want to develop with locally running backend
-const USE_PROD_BACKEND_FOR_DEV = false;
+const USE_PROD_BACKEND_FOR_DEV = true;
 
 export function grafanaUri() {
 	let uri = 'https://grafana.gratheon.com/'


### PR DESCRIPTION
## Why
New Feature - [Varroa Treatment diary](https://gratheon.notion.site/Varroa-Treatment-diary-90030bfde0c749ce922d43a2d46c273a?pvs=74) and this PR in particular is a very crude and basic support for marking bee colony as being treated

## Related PRs
- https://github.com/Gratheon/swarm-api/pull/3

## Changes
- update Apiary table view to now include queen age, last treatment and colony status (TBD)
- update hive edit view to now include list of treatments as well as ability to add new treatment
- group hive buttons to take less space
- move date formatting into date components to be more reuseable

![Screenshot 2024-07-07 at 03 20 11](https://github.com/Gratheon/web-app/assets/445122/dd30a936-cfc2-486d-81ce-f6f5c04c5a97)
![Screenshot 2024-07-07 at 03 20 04](https://github.com/Gratheon/web-app/assets/445122/77eb9059-f0f7-4884-bc5b-0b14ba17902f)
