### PR TITLE
add isNew badge, add last treatment column

### DIFF
--- a/src/components/page/apiaryList/apiaryListRow/index.less
+++ b/src/components/page/apiaryList/apiaryListRow/index.less
@@ -20,6 +20,17 @@ table {
 
 }
 
+.newHive{
+	background-color: green;
+	color: white;
+	padding:2px 5px;
+	margin-right: 5px;
+	margin-bottom: 5px;
+	text-transform: lowercase;
+	font-size:8px;
+	user-select: none;
+}
+
 .apiary {
 	padding: 10px 0;
 	border-bottom: 1px solid #eeeeee;

--- a/src/components/page/apiaryList/apiaryListRow/index.tsx
+++ b/src/components/page/apiaryList/apiaryListRow/index.tsx
@@ -68,8 +68,8 @@ export default function apiaryListRow({ apiary, user }) {
 								<th><T ctx="table header of beekeeping app, this is a column for beehive name, start with uppercase latter">Name</T></th>
 								<th><T ctx="table header of beekeeping app, start with uppercase latter">Bee count</T></th>
 								<th><T ctx="table header of beekeeping app, this is a bee colony information, start with uppercase latter">Colony status</T></th>
-								<th><T ctx="table header of beekeeping app, this is a bee queen info, start with uppercase latter">Queen age</T></th>
 								<th><T ctx="table header of beekeeping app, this column is about anti-varroa mite treatment, in amount of days, start with uppercase latter">Last treatment</T></th>
+								<th><T ctx="table header of beekeeping app, this column is about time when hive was checked, in amount of days, start with uppercase latter">Last inspection</T></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -82,6 +82,8 @@ export default function apiaryListRow({ apiary, user }) {
 											</NavLink>
 										</td>
 										<td>
+											{hive.isNew && <span className={styles.newHive}><T ctx="new beehive">New</T></span>}
+
 											<NavLink className={styles.title} to={`/apiaries/${apiary.id}/hives/${hive.id}`}>
 												{hive.name}
 											</NavLink>
@@ -91,9 +93,11 @@ export default function apiaryListRow({ apiary, user }) {
 											<BeeCounter count={hive.beeCount} />
 										</td>
 										<td>{hive.status}</td>
-										<td>{hive?.family?.age}</td>
 										<td>
 											{hive?.family?.lastTreatment && <DateTimeAgo dateString={hive?.family?.lastTreatment} lang={user.lang} />}
+										</td>
+										<td>
+											{hive?.lastInspection && <DateTimeAgo dateString={hive?.lastInspection} lang={user.lang} />}
 										</td>
 									</tr>
 								))}

--- a/src/components/page/apiaryList/index.tsx
+++ b/src/components/page/apiaryList/index.tsx
@@ -1,20 +1,21 @@
 import React from 'react'
+import { useLiveQuery } from 'dexie-react-hooks'
 
 import { gql, useQuery } from '@/components/api/index'
 
+import Button from '@/components/shared/button'
+import { getUser } from '@/components/models/user'
 import Loader from '@/components/shared/loader'
 import ErrorMsg from '@/components/shared/messageError'
 import T from '@/components/shared/translate'
 
 import ApiaryListRow from './apiaryListRow'
 import ApiariesPlaceholder from './apiariesPlaceholder'
-import Button from '@/components/shared/button'
-import { getUser } from '@/components/models/user'
-import { useLiveQuery } from 'dexie-react-hooks'
+
 
 export default function ApiaryList(props) {
 	let user = useLiveQuery(() => getUser(), [], null)
-	const { loading, error, data } = useQuery(gql`
+	const { loading, error, data, errorNetwork } = useQuery(gql`
 		{
 			apiaries {
 				id
@@ -25,6 +26,9 @@ export default function ApiaryList(props) {
 					name
 					beeCount
 					status
+
+					lastInspection
+					isNew
 
 					family{
 						id
@@ -51,7 +55,7 @@ export default function ApiaryList(props) {
 
 	return (
 		<div>
-			<ErrorMsg error={error} borderRadius={0} />
+			<ErrorMsg error={error || errorNetwork} borderRadius={0} />
 			<div style={{ maxWidth: 800, paddingLeft: 20 }}>
 				{apiaries !== null && apiaries?.length === 0 && <ApiariesPlaceholder />}
 

--- a/src/components/page/hiveCreate/index.tsx
+++ b/src/components/page/hiveCreate/index.tsx
@@ -11,7 +11,6 @@ import VisualFormSubmit from '@/components/shared/visualForm/VisualFormSubmit'
 import Button from '@/components/shared/button'
 import { Box, boxTypes } from '@/components/models/boxes'
 import T from '@/components/shared/translate'
-import MessageSuccess from '@/components/shared/messageSuccess'
 const defaultBoxColor = '#ffc848'
 
 export default function HiveCreateForm() {

--- a/src/components/page/hiveEdit/hiveTopInfo/index.tsx
+++ b/src/components/page/hiveEdit/hiveTopInfo/index.tsx
@@ -149,6 +149,7 @@ export default function HiveEditDetails({ apiaryId, hiveId }) {
 							{family && family.added}
 						</div>
 
+						{!family && <MessageSuccess title={<T>This hive has no family set yet</T>} isWarning={true} />}
 
 						{hive.notes && <p>{hive.notes}</p>}
 					</div>

--- a/src/components/page/hiveEdit/index.tsx
+++ b/src/components/page/hiveEdit/index.tsx
@@ -31,6 +31,7 @@ import TableIcon from '@/components/icons/tableIcon'
 
 import styles from './styles.less'
 import Treatments from './treatments'
+import { getFamilyByHive } from '@/components/models/family'
 
 export default function HiveEditForm() {
 	const { state } = useLocation();
@@ -43,6 +44,7 @@ export default function HiveEditForm() {
 	const apiary = useLiveQuery(() => getApiary(+apiaryId), [apiaryId], null)
 	const hive = useLiveQuery(() => getHive(+hiveId), [hiveId], null)
 	const box = useLiveQuery(() => getBox(+boxId), [boxId], null)
+	const family = useLiveQuery(() => getFamilyByHive(+hiveId), [hiveId])
 
 	if (apiary === null || hive === null) {
 		return <Loader />
@@ -166,7 +168,7 @@ export default function HiveEditForm() {
 					{!frameId && !boxId && <HiveButtons apiaryId={apiaryId} hiveId={hiveId} />}
 
 
-					{!frameId && <Treatments hiveId={hiveId} boxId={boxId} />}
+					{!frameId && family && <Treatments hiveId={hiveId} boxId={boxId} />}
 
 					<Frame
 						box={box}

--- a/src/components/page/hiveEdit/treatments/index.tsx
+++ b/src/components/page/hiveEdit/treatments/index.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
 
-import { gql, useMutation, useQuery } from "@/components/api";
+import { useMutation } from "@/components/api";
 import Button from "@/components/shared/button";
 import ErrorMessage from '@/components/shared/messageError'
 import T from "@/components/shared/translate";
 import Loader from "@/components/shared/loader";
-import DateFormat from "@/components/shared/dateFormat";
 import MessageSuccess from "@/components/shared/messageSuccess";
 import TreatmentList from "./treatmentList";
 

--- a/src/components/page/hiveEdit/treatments/treatmentList/index.tsx
+++ b/src/components/page/hiveEdit/treatments/treatmentList/index.tsx
@@ -1,12 +1,10 @@
 import { useState } from "react";
 
-import { gql, useMutation, useQuery } from "@/components/api";
-import Button from "@/components/shared/button";
+import { gql, useQuery } from "@/components/api";
 import ErrorMessage from '@/components/shared/messageError'
 import T from "@/components/shared/translate";
 import Loader from "@/components/shared/loader";
 import DateFormat from "@/components/shared/dateFormat";
-import MessageSuccess from "@/components/shared/messageSuccess";
 
 export default function TreatmentList({ hiveId, boxId = null }) {
 	let {
@@ -36,8 +34,8 @@ export default function TreatmentList({ hiveId, boxId = null }) {
 		<>
 			<ErrorMessage error={errorGet || errorNetwork} />
 
-			{data.hive.family.treatments.length == 0 && <p><T>No treatments added yet</T></p>}
-			{data.hive.family.treatments.length > 0 &&
+			{data.hive.family && data.hive.family.treatments.length == 0 && <p><T>No treatments added yet</T></p>}
+			{data.hive.family && data.hive.family.treatments.length > 0 &&
 				<table width="100%">
 					<thead>
 						<tr>


### PR DESCRIPTION
## Why
noticed that in steam, after new games are bought they have `new` badge..
this seemed like an easy addition to our case when new hive is created, we can show for 1 day that its new too

also removed family age column and instead added last inspection time
![Screenshot 2024-07-08 at 02 42 56](https://github.com/Gratheon/web-app/assets/445122/525ec04f-6cce-49af-aa45-d5f310f2e808)
