### PR TITLE
fix entrance section access/on-click not working

### DIFF
--- a/src/components/page/hiveEdit/boxes/index.tsx
+++ b/src/components/page/hiveEdit/boxes/index.tsx
@@ -64,7 +64,8 @@ export default function Boxes({
 		if (
 			typeof event.target.className === 'string' &&
 			event.target.className.length > 0 &&
-			event.target.className.indexOf('box') >=0
+			(event.target.className.indexOf('box') >=0 ||
+			event.target.className.indexOf('gate') >=0)
 		) {
 			event.stopPropagation()
 			navigate(`/apiaries/${apiaryId}/hives/${hiveId}/box/${boxId}`, {


### PR DESCRIPTION
## Why
Clicking on hive entrance is not working
<img width="777" alt="Screenshot 2024-07-24 at 23 27 04" src="https://github.com/user-attachments/assets/298aa782-b14c-4aaf-9a5d-17f202c88d84">


## Changes
- update `onBoxClick` to allow navigation to hive entrance view

The background is that this function intercepts clicks in order to allow navigation to hive frames separate from hive sections. If we wouldn't do that, clicking on frame would trigger also onBoxClick.. so I don't have a good solution atm that having check of target element classes.